### PR TITLE
修改字段名称, 根据官方文档对比实际测试结果

### DIFF
--- a/src/main/java/weixin/popular/bean/component/ApiGetAuthorizerInfoResult.java
+++ b/src/main/java/weixin/popular/bean/component/ApiGetAuthorizerInfoResult.java
@@ -192,16 +192,16 @@ public class ApiGetAuthorizerInfoResult extends BaseResult {
 
 	public static class Authorization_info {
 
-		private String appid;
+		private String authorizer_appid;
 
 		private List<FuncInfo> func_info;
 
-		public String getAppid() {
-			return appid;
+		public String getAuthorizer_appid() {
+			return authorizer_appid;
 		}
 
-		public void setAppid(String appid) {
-			this.appid = appid;
+		public void setAuthorizer_appid(String authorizer_appid) {
+			this.authorizer_appid = authorizer_appid;
 		}
 
 		public List<FuncInfo> getFunc_info() {


### PR DESCRIPTION
## 修改字段名称
### 官方文档说明
微信公众号第三方平台授权流程([文档](https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1453779503&token=&lang=zh_CN))，第6步：获取授权方的公众号帐号基本信息，授权权限集部分，返回字段是：**授权信息-授权方appid(即第三方公众平台的appid)**
 ### 实际返回内容为
  `{
	"authorizer_info": {
		"nick_name": "**",
		"head_img": "http:\/\/wx.qlogo.cn\/mmopen\/I44ic623iaRlZ156Svrt0WBSI3VqKQuzriaRT3H4DOjvM7uUaxVQPkzfBwKVy2YjYRxtibWfCeXxpXED4w9ib**E516gqIKGNrgOV\/0",
		"service_type_info": {
			"id": 0
		},
		"verify_type_info": {
			"id": -1
		},
		"user_name": "gh_6da*****0087",
		"alias": "******",
		"qrcode_url": "http:\/\/mmbiz.qpic.cn\/mmbiz_jpg\/95nAC8wN374Xj5a35hU8ia8jYkHzhyn703IvibSufSDIicRibbicLC4cL2ZkF5hWCKPcDgjdGqAf2icEhtN**iaeXCgcw\/0",
		"business_info": {
			"open_pay": 0,
			"open_shake": 0,
			"open_scan": 0,
			"open_card": 0,
			"open_store": 0
		},
		"idc": 1
	},
	"authorization_info": {
		"authorizer_appid": "wxf05867*****788e",
		`"func_info": [{"funcscope_category": {"id": 1}}...`

对比**wxf05867#####788e**确实是自己的公众号appid而不是授权方(appid)。
故修改**weixin.popular.bean.component.ApiGetAuthorizerInfoResult**中第195行 **appid 为 authorizer_appid**，以及相应的get和set方法。
以上是实际测试结果，github第一次pull request，不足之处，敬请指正！

附图：微信返回的数据
![2016-11-04_102411](https://cloud.githubusercontent.com/assets/7442217/19992680/eb712078-a27a-11e6-8c7b-1a93fd94bf5d.jpg)