### PR TITLE
修复体验账号解绑不成功的问题

### DIFF
--- a/src/main/java/weixin/popular/api/WxaAPI.java
+++ b/src/main/java/weixin/popular/api/WxaAPI.java
@@ -83,7 +83,7 @@ public class WxaAPI extends BaseAPI {
 	 */
 	public static BaseResult unbind_tester(String access_token,String wechatid){
 		String json = String.format("{\"wechatid\":\"%s\"}",wechatid);
-		HttpUriRequest httpUriRequest = RequestBuilder.get()
+		HttpUriRequest httpUriRequest = RequestBuilder.post()
 				.setHeader(jsonHeader)
 				.setUri(BASE_URI+"/wxa/unbind_tester")
 				.addParameter(PARAM_ACCESS_TOKEN, API.accessToken(access_token))


### PR DESCRIPTION
根据文档
https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1489140588_nVUgx&token=&lang=zh_CN
以及使用get时返回的错误：
    "errcode": "43002",
    "errmsg": "require POST method hint: [.I0KUa0172e626]",
    "success": false
请求类型应该是post，而不是get