### PR TITLE
忽略IntelliJ IDEA导入项目时生成的配置文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.jar
 *.war
 *.ear
+*.iml
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
@@ -14,3 +15,4 @@ hs_err_pid*
 /.settings/
 /.classpath
 /.project
+/.idea


### PR DESCRIPTION
忽略IntelliJ IDEA导入项目时生成的配置文件