### PR TITLE
添加带字符串参数的临时二维码生成接口

### DIFF
--- a/src/main/java/weixin/popular/api/QrcodeAPI.java
+++ b/src/main/java/weixin/popular/api/QrcodeAPI.java
@@ -55,6 +55,19 @@ public class QrcodeAPI extends BaseAPI{
 	}
 
 	/**
+	 * 创建带参数的临时二维码
+	 * 具体信息可以查看<a href="https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1443433542">微信公众号文档</a>
+	 * @param access_token access_token
+	 * @param expire_seconds 最大不超过604800秒（即30天）
+	 * @param scene_str		 场景值ID（字符串形式的ID），字符串类型，长度限制为1到64
+	 * @return QrcodeTicket
+	 */
+	public static QrcodeTicket qrcodeCreateTemp(String access_token,int expire_seconds,String scene_str){
+		String json = String.format("{\"expire_seconds\": %d, \"action_name\": \"QR_SCENE\", \"action_info\": {\"scene\": {\"scene_str\": %s}}}",expire_seconds,scene_str);
+		return qrcodeCreate(access_token,json);
+	}
+
+	/**
 	 * 创建持久二维码
 	 * @param access_token access_token
 	 * @param scene_id	场景值ID 1-100000
@@ -64,7 +77,7 @@ public class QrcodeAPI extends BaseAPI{
 		String json = String.format("{\"action_name\": \"QR_LIMIT_SCENE\", \"action_info\": {\"scene\": {\"scene_id\":%d}}}", scene_id);
 		return qrcodeCreate(access_token,json);
 	}
-	
+
 	/**
 	 * 创建持久二维码
 	 * @param access_token access_token
@@ -87,24 +100,9 @@ public class QrcodeAPI extends BaseAPI{
 				.addParameter("ticket", ticket)
 				.build();
 		CloseableHttpResponse httpResponse = LocalHttpClient.execute(httpUriRequest);
-		try {
-			int status = httpResponse.getStatusLine().getStatusCode();
-            if (status == 200) {
-				byte[] bytes = EntityUtils.toByteArray(httpResponse.getEntity());
-				return ImageIO.read(new ByteArrayInputStream(bytes));
-            }
-		} catch (IOException e) {
-			e.printStackTrace();
-		} finally {
-			try {
-				httpResponse.close();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
-		return null;
+		return getImage(httpResponse);
 	}
-	
+
 	/**
 	 * 获取小程序页面二维码 <br>
 	 * 小程序码使用 使用 WxaAPI.getwxacode　或　WxaAPI.getwxacodeunlimit
@@ -122,12 +120,16 @@ public class QrcodeAPI extends BaseAPI{
 								.setEntity(new StringEntity(json,Charset.forName("utf-8")))
 								.build();
 		CloseableHttpResponse httpResponse = LocalHttpClient.execute(httpUriRequest);
+		return getImage(httpResponse);
+	}
+
+	private static BufferedImage getImage(CloseableHttpResponse httpResponse) {
 		try {
 			int status = httpResponse.getStatusLine().getStatusCode();
-            if (status == 200) {
+			if (status == 200) {
 				byte[] bytes = EntityUtils.toByteArray(httpResponse.getEntity());
 				return ImageIO.read(new ByteArrayInputStream(bytes));
-            }
+			}
 		} catch (IOException e) {
 			e.printStackTrace();
 		} finally {


### PR DESCRIPTION
* 添加带字符串参数的临时二维码生成，微信是支持的,[微信文档](https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1443433542)
* 静态类中有重复代码，顺手重构