### PR TITLE
修复WxaUtil的decryptUserInfo方法中文乱码问题

### DIFF
--- a/src/main/java/weixin/popular/util/WxaUtil.java
+++ b/src/main/java/weixin/popular/util/WxaUtil.java
@@ -1,11 +1,13 @@
 package weixin.popular.util;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import com.sun.xml.internal.fastinfoset.Encoder;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
@@ -44,7 +46,7 @@ public abstract class WxaUtil {
 			Key sKeySpec = new SecretKeySpec(Base64.decodeBase64(session_key), "AES");
 			cipher.init(Cipher.DECRYPT_MODE, sKeySpec, new IvParameterSpec(Base64.decodeBase64(iv)));
 			byte[] resultByte = cipher.doFinal(Base64.decodeBase64(encryptedData));
-			String data = new String(PKCS7Encoder.decode(resultByte));
+			String data = new String(PKCS7Encoder.decode(resultByte), StandardCharsets.UTF_8);
 			return JsonUtil.parseObject(data, WxaDUserInfo.class);
 		} catch (Exception e) {
 			logger.error("", e);

--- a/src/main/java/weixin/popular/util/WxaUtil.java
+++ b/src/main/java/weixin/popular/util/WxaUtil.java
@@ -7,7 +7,6 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import com.sun.xml.internal.fastinfoset.Encoder;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;


### PR DESCRIPTION
Base64字符串decode时调用的是`StringUtils.getBytesUtf8()`方法，指定了utf-8编码，而最后结果调用String构造函数时未指定编码，将使用`Charset.defaultCharset()`的默认编码，在有些机器上出现中文乱码的情况。