### PR TITLE
增加微信草稿箱以及发布能力相关接口, 发送图文消息支持已发布素材类型

### DIFF
--- a/src/main/java/weixin/popular/api/DraftAPI.java
+++ b/src/main/java/weixin/popular/api/DraftAPI.java
@@ -1,0 +1,46 @@
+package weixin.popular.api;
+
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.StringEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import weixin.popular.bean.draft.DraftBatchGetResult;
+import weixin.popular.bean.draft.DraftItemResult;
+import weixin.popular.client.LocalHttpClient;
+
+import java.nio.charset.Charset;
+
+/**
+ * 草稿箱
+ * <p>
+ * Created by songfan on 2021/12/8.
+ */
+public class DraftAPI extends BaseAPI {
+
+    private static Logger logger = LoggerFactory.getLogger(FreePublishAPI.class);
+
+    public static DraftBatchGetResult draftBatchGet(String accessToken, String requestJson) {
+        HttpUriRequest httpUriRequest = RequestBuilder
+                .post()
+                .setHeader(jsonHeader)
+                .setUri(BASE_URI + "/cgi-bin/draft/batchget")
+                .addParameter(PARAM_ACCESS_TOKEN, API.accessToken(accessToken))
+                .setEntity(new StringEntity(requestJson, Charset.forName("UTF-8")))
+                .build();
+        return LocalHttpClient.executeJsonResult(httpUriRequest,
+                DraftBatchGetResult.class);
+    }
+
+    public static DraftItemResult getDraft(String accessToken, String requestJson) {
+        HttpUriRequest httpUriRequest = RequestBuilder
+                .post()
+                .setHeader(jsonHeader)
+                .setUri(BASE_URI + "/cgi-bin/draft/get")
+                .addParameter(PARAM_ACCESS_TOKEN, API.accessToken(accessToken))
+                .setEntity(new StringEntity(requestJson, Charset.forName("UTF-8")))
+                .build();
+        return LocalHttpClient.executeJsonResult(httpUriRequest,
+                DraftItemResult.class);
+    }
+}

--- a/src/main/java/weixin/popular/api/FreePublishAPI.java
+++ b/src/main/java/weixin/popular/api/FreePublishAPI.java
@@ -1,0 +1,58 @@
+package weixin.popular.api;
+
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.StringEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import weixin.popular.bean.freepublish.ArticleBatchGetResult;
+import weixin.popular.bean.freepublish.ArticleItemResult;
+import weixin.popular.client.LocalHttpClient;
+
+import java.nio.charset.Charset;
+
+/**
+ * 发布接口
+ * <p>
+ * Created by songfan on 2021/10/29.
+ */
+public class FreePublishAPI extends BaseAPI {
+
+    private static Logger logger = LoggerFactory.getLogger(FreePublishAPI.class);
+
+    /**
+     * 开发者可以获取已成功发布的消息列表
+     * 参数	        是否必须	 说明
+     * access_token	 是	    调用接口凭证
+     * offset	     是	    从全部素材的该偏移位置开始返回，0表示从第一个素材返回
+     * count	     是	    返回素材的数量，取值在1到20之间
+     * no_content	 否	    1 表示不返回 content 字段，0 表示正常返回，默认为 0
+     *
+     * @param accessToken
+     * @param requestJson
+     * @return
+     */
+    public static ArticleBatchGetResult freePublishBatchGet(String accessToken, String requestJson) {
+        HttpUriRequest httpUriRequest = RequestBuilder
+                .post()
+                .setHeader(jsonHeader)
+                .setUri(BASE_URI + "/cgi-bin/freepublish/batchget")
+                .addParameter(PARAM_ACCESS_TOKEN, API.accessToken(accessToken))
+                .setEntity(new StringEntity(requestJson, Charset.forName("UTF-8")))
+                .build();
+        return LocalHttpClient.executeJsonResult(httpUriRequest,
+                ArticleBatchGetResult.class);
+    }
+
+    public static ArticleItemResult getArticle(String accessToken, String requestJson) {
+        HttpUriRequest httpUriRequest = RequestBuilder
+                .post()
+                .setHeader(jsonHeader)
+                .setUri(BASE_URI + "/cgi-bin/freepublish/getarticle")
+                .addParameter(PARAM_ACCESS_TOKEN, API.accessToken(accessToken))
+                .setEntity(new StringEntity(requestJson, Charset.forName("UTF-8")))
+                .build();
+        return LocalHttpClient.executeJsonResult(httpUriRequest,
+                ArticleItemResult.class);
+    }
+}

--- a/src/main/java/weixin/popular/bean/draft/DraftBatchGetResult.java
+++ b/src/main/java/weixin/popular/bean/draft/DraftBatchGetResult.java
@@ -1,0 +1,91 @@
+package weixin.popular.bean.draft;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import weixin.popular.bean.BaseResult;
+
+import java.util.List;
+
+/**
+ * Created by songfan on 2021/10/29.
+ */
+public class DraftBatchGetResult extends BaseResult {
+
+    /**
+     * 草稿素材的总数
+     */
+    @JSONField(name = "total_count")
+    private Integer totalCount;
+
+    /**
+     * 本次调用获取的素材的数量
+     */
+    @JSONField(name = "item_count")
+    private Integer itemCount;
+
+    private List<Item> item;
+
+    public Integer getTotalCount() {
+        return totalCount;
+    }
+
+    public void setTotalCount(Integer totalCount) {
+        this.totalCount = totalCount;
+    }
+
+    public Integer getItemCount() {
+        return itemCount;
+    }
+
+    public void setItemCount(Integer itemCount) {
+        this.itemCount = itemCount;
+    }
+
+    public List<Item> getItem() {
+        return item;
+    }
+
+    public void setItem(List<Item> item) {
+        this.item = item;
+    }
+
+    public static class Item {
+
+        /**
+         * 图文消息的id
+         */
+        @JSONField(name = "media_id")
+        private String mediaId;
+
+        /**
+         * 图文消息的具体内容，支持HTML标签，必须少于2万字符，小于1M，且此处会去除JS。
+         */
+        private DraftItemResult content;
+
+        @JSONField(name = "update_time")
+        private Long updateTime;
+
+        public String getMediaId() {
+            return mediaId;
+        }
+
+        public void setMediaId(String mediaId) {
+            this.mediaId = mediaId;
+        }
+
+        public DraftItemResult getContent() {
+            return content;
+        }
+
+        public void setContent(DraftItemResult content) {
+            this.content = content;
+        }
+
+        public Long getUpdateTime() {
+            return updateTime;
+        }
+
+        public void setUpdateTime(Long updateTime) {
+            this.updateTime = updateTime;
+        }
+    }
+}

--- a/src/main/java/weixin/popular/bean/draft/DraftItemResult.java
+++ b/src/main/java/weixin/popular/bean/draft/DraftItemResult.java
@@ -1,0 +1,195 @@
+package weixin.popular.bean.draft;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import weixin.popular.bean.BaseResult;
+
+import java.util.List;
+
+/**
+ * Created by songfan on 2021/10/29.
+ */
+public class DraftItemResult extends BaseResult {
+
+    @JSONField(name = "news_item")
+    private List<NewsItem> newsItem;
+
+    @JSONField(name = "create_time")
+    private Long createTime;
+
+    @JSONField(name = "update_time")
+    private Long updateTime;
+
+    public List<NewsItem> getNewsItem() {
+        return newsItem;
+    }
+
+    public void setNewsItem(List<NewsItem> newsItem) {
+        this.newsItem = newsItem;
+    }
+
+    public Long getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Long createTime) {
+        this.createTime = createTime;
+    }
+
+    public Long getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(Long updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public static class NewsItem {
+        /**
+         * 图文消息的标题
+         */
+        private String title;
+
+        /**
+         * 作者
+         */
+        private String author;
+
+        /**
+         * 图文消息的摘要，仅有单图文消息才有摘要，多图文此处为空。
+         */
+        private String digest;
+
+        /**
+         * 图文消息的具体内容，支持HTML标签，必须少于2万字符，小于1M，且此处会去除JS。
+         */
+        private String content;
+
+        /**
+         * 图文消息的原文地址，即点击“阅读原文”后的URL
+         */
+        @JSONField(name = "content_source_url")
+        private String contentSourceUrl;
+
+        /**
+         * 图文消息的封面图片素材id（一定是永久MediaID）
+         */
+        @JSONField(name = "thumb_media_id")
+        private String thumbMediaId;
+
+        /**
+         * 是否显示封面，0为false，即不显示，1为true，即显示(默认)
+         */
+        @JSONField(name = "show_cover_pic")
+        private Integer showCoverPic;
+
+        /**
+         * Uint32 是否打开评论，0不打开(默认)，1打开
+         */
+        @JSONField(name = "need_open_comment")
+        private Integer needOpenComment;
+
+        /**
+         * Uint32 是否粉丝才可评论，0所有人可评论(默认)，1粉丝才可评论
+         */
+        @JSONField(name = "only_fans_can_comment")
+        private Integer onlyFansCanComment;
+
+        /**
+         * 图文消息的URL
+         */
+        private String url;
+
+        @JSONField(name = "thumb_url")
+        private String thumbUrl;
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getAuthor() {
+            return author;
+        }
+
+        public void setAuthor(String author) {
+            this.author = author;
+        }
+
+        public String getDigest() {
+            return digest;
+        }
+
+        public void setDigest(String digest) {
+            this.digest = digest;
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public void setContent(String content) {
+            this.content = content;
+        }
+
+        public String getContentSourceUrl() {
+            return contentSourceUrl;
+        }
+
+        public void setContentSourceUrl(String contentSourceUrl) {
+            this.contentSourceUrl = contentSourceUrl;
+        }
+
+        public String getThumbMediaId() {
+            return thumbMediaId;
+        }
+
+        public void setThumbMediaId(String thumbMediaId) {
+            this.thumbMediaId = thumbMediaId;
+        }
+
+        public Integer getShowCoverPic() {
+            return showCoverPic;
+        }
+
+        public void setShowCoverPic(Integer showCoverPic) {
+            this.showCoverPic = showCoverPic;
+        }
+
+        public Integer getNeedOpenComment() {
+            return needOpenComment;
+        }
+
+        public void setNeedOpenComment(Integer needOpenComment) {
+            this.needOpenComment = needOpenComment;
+        }
+
+        public Integer getOnlyFansCanComment() {
+            return onlyFansCanComment;
+        }
+
+        public void setOnlyFansCanComment(Integer onlyFansCanComment) {
+            this.onlyFansCanComment = onlyFansCanComment;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+
+        public String getThumbUrl() {
+            return thumbUrl;
+        }
+
+        public void setThumbUrl(String thumbUrl) {
+            this.thumbUrl = thumbUrl;
+        }
+    }
+
+
+}

--- a/src/main/java/weixin/popular/bean/freepublish/ArticleBatchGetResult.java
+++ b/src/main/java/weixin/popular/bean/freepublish/ArticleBatchGetResult.java
@@ -1,0 +1,79 @@
+package weixin.popular.bean.freepublish;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import weixin.popular.bean.BaseResult;
+
+import java.util.List;
+
+/**
+ * Created by songfan on 2021/10/29.
+ */
+public class ArticleBatchGetResult extends BaseResult {
+
+    /**
+     * 成功发布素材的总数
+     */
+    @JSONField(name = "total_count")
+    private Integer totalCount;
+
+    /**
+     * 本次调用获取的素材的数量
+     */
+    @JSONField(name = "item_count")
+    private Integer itemCount;
+
+    private List<Item> item;
+
+    public Integer getTotalCount() {
+        return totalCount;
+    }
+
+    public void setTotalCount(Integer totalCount) {
+        this.totalCount = totalCount;
+    }
+
+    public Integer getItemCount() {
+        return itemCount;
+    }
+
+    public void setItemCount(Integer itemCount) {
+        this.itemCount = itemCount;
+    }
+
+    public List<Item> getItem() {
+        return item;
+    }
+
+    public void setItem(List<Item> item) {
+        this.item = item;
+    }
+
+    public static class Item {
+        /**
+         * 成功发布的图文消息id
+         */
+        @JSONField(name = "article_id")
+        private String articleId;
+
+        /**
+         * 图文消息的具体内容，支持HTML标签，必须少于2万字符，小于1M，且此处会去除JS。
+         */
+        private ArticleItemResult content;
+
+        public String getArticleId() {
+            return articleId;
+        }
+
+        public void setArticleId(String articleId) {
+            this.articleId = articleId;
+        }
+
+        public ArticleItemResult getContent() {
+            return content;
+        }
+
+        public void setContent(ArticleItemResult content) {
+            this.content = content;
+        }
+    }
+}

--- a/src/main/java/weixin/popular/bean/freepublish/ArticleItemResult.java
+++ b/src/main/java/weixin/popular/bean/freepublish/ArticleItemResult.java
@@ -1,0 +1,209 @@
+package weixin.popular.bean.freepublish;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import weixin.popular.bean.BaseResult;
+
+import java.util.List;
+
+/**
+ * Created by songfan on 2021/10/29.
+ */
+public class ArticleItemResult extends BaseResult {
+
+    @JSONField(name = "news_item")
+    private List<NewsItem> newsItem;
+
+    @JSONField(name = "create_time")
+    private Long createTime;
+
+    @JSONField(name = "update_time")
+    private Long updateTime;
+
+    public List<NewsItem> getNewsItem() {
+        return newsItem;
+    }
+
+    public void setNewsItem(List<NewsItem> newsItem) {
+        this.newsItem = newsItem;
+    }
+
+    public Long getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Long createTime) {
+        this.createTime = createTime;
+    }
+
+    public Long getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(Long updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public static class NewsItem {
+        /**
+         * 图文消息的标题
+         */
+        private String title;
+
+        /**
+         * 作者
+         */
+        private String author;
+
+        /**
+         * 图文消息的摘要，仅有单图文消息才有摘要，多图文此处为空。
+         */
+        private String digest;
+
+        /**
+         * 图文消息的具体内容，支持HTML标签，必须少于2万字符，小于1M，且此处会去除JS。
+         */
+        private String content;
+
+        /**
+         * 图文消息的原文地址，即点击“阅读原文”后的URL
+         */
+        @JSONField(name = "content_source_url")
+        private String contentSourceUrl;
+
+        /**
+         * 图文消息的封面图片素材id（一定是永久MediaID）
+         */
+        @JSONField(name = "thumb_media_id")
+        private String thumbMediaId;
+
+        /**
+         * 是否显示封面，0为false，即不显示，1为true，即显示(默认)
+         */
+        @JSONField(name = "show_cover_pic")
+        private Integer showCoverPic;
+
+        /**
+         * Uint32 是否打开评论，0不打开(默认)，1打开
+         */
+        @JSONField(name = "need_open_comment")
+        private Integer needOpenComment;
+
+        /**
+         * Uint32 是否粉丝才可评论，0所有人可评论(默认)，1粉丝才可评论
+         */
+        @JSONField(name = "only_fans_can_comment")
+        private Integer onlyFansCanComment;
+
+        /**
+         * 图文消息的URL
+         */
+        private String url;
+
+        @JSONField(name = "thumb_url")
+        private String thumbUrl;
+
+        /**
+         * 该图文是否被删除
+         */
+        @JSONField(name = "is_deleted")
+        private Boolean isDeleted;
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getAuthor() {
+            return author;
+        }
+
+        public void setAuthor(String author) {
+            this.author = author;
+        }
+
+        public String getDigest() {
+            return digest;
+        }
+
+        public void setDigest(String digest) {
+            this.digest = digest;
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public void setContent(String content) {
+            this.content = content;
+        }
+
+        public String getContentSourceUrl() {
+            return contentSourceUrl;
+        }
+
+        public void setContentSourceUrl(String contentSourceUrl) {
+            this.contentSourceUrl = contentSourceUrl;
+        }
+
+        public String getThumbMediaId() {
+            return thumbMediaId;
+        }
+
+        public void setThumbMediaId(String thumbMediaId) {
+            this.thumbMediaId = thumbMediaId;
+        }
+
+        public Integer getShowCoverPic() {
+            return showCoverPic;
+        }
+
+        public void setShowCoverPic(Integer showCoverPic) {
+            this.showCoverPic = showCoverPic;
+        }
+
+        public Integer getNeedOpenComment() {
+            return needOpenComment;
+        }
+
+        public void setNeedOpenComment(Integer needOpenComment) {
+            this.needOpenComment = needOpenComment;
+        }
+
+        public Integer getOnlyFansCanComment() {
+            return onlyFansCanComment;
+        }
+
+        public void setOnlyFansCanComment(Integer onlyFansCanComment) {
+            this.onlyFansCanComment = onlyFansCanComment;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+
+        public Boolean getDeleted() {
+            return isDeleted;
+        }
+
+        public void setDeleted(Boolean deleted) {
+            isDeleted = deleted;
+        }
+
+        public String getThumbUrl() {
+            return thumbUrl;
+        }
+
+        public void setThumbUrl(String thumbUrl) {
+            this.thumbUrl = thumbUrl;
+        }
+    }
+
+
+}

--- a/src/main/java/weixin/popular/bean/message/message/MpArticleMessage.java
+++ b/src/main/java/weixin/popular/bean/message/message/MpArticleMessage.java
@@ -1,0 +1,33 @@
+package weixin.popular.bean.message.message;
+
+/**
+ * 发送图文消息（点击跳转到图文消息页面）使用通过 “发布” 系列接口得到的 article_id
+ * 注意: 草稿接口灰度完成后，将不再支持此前客服接口中带 media_id 的 mpnews 类型的图文消息
+ * <p>
+ * Created by songfan on 2021/12/8.
+ */
+public class MpArticleMessage extends Message {
+
+    public MpArticleMessage() {
+    }
+
+    public MpArticleMessage(String toUser, String articleId) {
+        super(toUser, "mpnewsarticle");
+        this.mpnewsarticle = new MpArticle();
+        this.mpnewsarticle.setArticle_id(articleId);
+    }
+
+    private MpArticle mpnewsarticle;
+
+    public static class MpArticle {
+        private String article_id;
+
+        public String getArticle_id() {
+            return article_id;
+        }
+
+        public void setArticle_id(String article_id) {
+            this.article_id = article_id;
+        }
+    }
+}


### PR DESCRIPTION
增加微信草稿箱以及发布能力模块中获取单条记录以及批量获取的接口
支持发送“已发布素材”类型的图文消息